### PR TITLE
Fix delta-server linking issues by including missing source files in …

### DIFF
--- a/BUILD_FIX_SUMMARY.md
+++ b/BUILD_FIX_SUMMARY.md
@@ -1,25 +1,31 @@
 # Build Fix Summary
 
 ## Problem
-The `delta-server` executable was failing to link with the error:
+The `delta-server` executable was failing to link with multiple undefined symbol errors:
 ```
 Undefined symbols for architecture arm64:
   "delta::Commands::launch_server_auto(...)"
+  "delta::InferenceEngine::load_model(...)"
+  "delta::tools::Browser::open_url(...)"
 ```
 
 ## Root Cause
-The `model_api_server.cpp` file calls `Commands::launch_server_auto()`, but `commands.cpp` was not included in the `delta-server` executable build.
+1. The `model_api_server.cpp` file calls `Commands::launch_server_auto()`, but `commands.cpp` was not included in the `delta-server` executable build.
+2. `commands.cpp` uses `InferenceEngine::load_model()` from `inference.cpp`
+3. `commands.cpp` uses `tools::Browser::open_url()` from `tools/browser.cpp`
 
 ## Solution
-Added `src/commands.cpp` to the `delta-server` executable in `CMakeLists.txt`:
+Added the missing source files to the `delta-server` executable in `CMakeLists.txt`:
 
 ```cmake
 add_executable(delta-server 
     src/delta_server_wrapper.cpp 
     src/model_api_server.cpp
     src/models.cpp
-    src/commands.cpp          # ← Added this
+    src/commands.cpp          # ← Added for launch_server_auto
+    src/inference.cpp         # ← Added for InferenceEngine
     src/tools/file_ops.cpp
+    src/tools/browser.cpp     # ← Added for Browser::open_url
     src/ui.cpp
 )
 ```

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,12 +151,15 @@ endif()
 
 # Delta Server Wrapper (customized llama-server)
 # Need to include models.cpp for ModelManager and commands.cpp for launch_server_auto
+# Also need inference.cpp and tools/browser.cpp for commands.cpp dependencies
 add_executable(delta-server 
     src/delta_server_wrapper.cpp 
     src/model_api_server.cpp
     src/models.cpp
     src/commands.cpp
+    src/inference.cpp
     src/tools/file_ops.cpp
+    src/tools/browser.cpp
     src/ui.cpp
 )
 


### PR DESCRIPTION
…CMake configuration

- Added commands.cpp, inference.cpp, and tools/browser.cpp to the delta-server executable in CMakeLists.txt to resolve multiple undefined symbol errors during linking.
- Updated documentation in BUILD_FIX_SUMMARY.md to reflect the changes and clarify the root cause of the linking issues.