### PR TITLE
Enhance model path handling for llama-server: Updated launch_server_a…

### DIFF
--- a/packaging/homebrew/README.md
+++ b/packaging/homebrew/README.md
@@ -1,0 +1,41 @@
+# Homebrew formula for Delta CLI
+
+This directory contains the **canonical** Homebrew formula for Delta CLI.
+
+## Install from this repo (recommended for tap users)
+
+To get a working install that includes the **llama.cpp server** binary (required for `delta` and `delta-server` to run), use the formula in this repo:
+
+```bash
+brew tap nile-agi/delta-cli
+brew install --HEAD nile-agi/delta-cli/delta-cli
+```
+
+**Important:** The tap repo [nile-agi/homebrew-delta-cli](https://github.com/nile-agi/homebrew-delta-cli) must use a formula that **installs the llama.cpp server binary** (as `server` next to `delta` and `delta-server`). This repo’s `delta-cli.rb` does that; if the tap’s copy does not, you will see:
+
+- `Error: HTTP server binary ('server') not found` when running `delta`, or  
+- Delta will not start the backend.
+
+**Tap maintainers:** Keep the tap’s `Formula/delta-cli.rb` in sync with this file, especially the block that finds and installs the server binary (the `server_path` / `bin.install server_path => "server"` section). Without it, only `delta` and `delta-server` are installed and the wrapper cannot find llama-server.
+
+## After install
+
+1. Ensure at least one model is available:
+   ```bash
+   delta pull qwen2.5:0.5b
+   ```
+2. Run:
+   ```bash
+   delta
+   ```
+   or `delta server`. The server always uses `-m <absolute path>` (no `--models-dir`), so it works on all macOS/Homebrew builds.
+
+## Local install from this repo
+
+From the **delta repo root** (not the tap):
+
+```bash
+brew install --HEAD ./packaging/homebrew/delta-cli.rb
+```
+
+This uses the formula in this repo and installs the server binary correctly.

--- a/src/commands.h
+++ b/src/commands.h
@@ -59,7 +59,7 @@ public:
     static bool process_command(const std::string& input, InteractiveSession& session);
     
     // Launch server automatically (for auto-start on delta launch). Uses port 8080 only.
-    // If model_path empty and models_dir non-empty, starts in router mode (llama-server scans models_dir for .gguf).
+    // Launches llama-server with -m <path>. If model_path empty and models_dir set, uses first .gguf in models_dir.
     static bool launch_server_auto(const std::string& model_path, int port = 8080, int ctx_size = 0, const std::string& model_alias = "", const std::string& models_dir = "");
     
     // Restart llama-server with new model (for model switching)
@@ -96,7 +96,7 @@ private:
     static int current_port_;
     static std::mutex server_mutex_;
     
-    // Helper to build llama-server command. If model_path empty and models_dir non-empty, router mode (no -m).
+    // Helper to build llama-server command (always -m with absolute path).
     static std::string build_llama_server_cmd(const std::string& server_bin, const std::string& model_path,
                                                int port, int ctx_size, const std::string& model_alias,
                                                const std::string& public_path, const std::string& models_dir = "");

--- a/src/delta_cli.h
+++ b/src/delta_cli.h
@@ -330,6 +330,8 @@ public:
     static std::vector<std::string> list_dir(const std::string& path);
     /** Return full path of first .gguf file in directory, or "" if none. For server compatibility when --models-dir is not supported. */
     static std::string first_gguf_in_dir(const std::string& path);
+    /** Resolve path to absolute so llama-server can find the model regardless of cwd. Returns empty if path is empty or resolution fails. */
+    static std::string absolute_path(const std::string& path);
     static std::string get_home_dir();
     static std::string join_path(const std::string& a, const std::string& b);
     static std::string get_executable_dir();

--- a/src/tools/file_ops.cpp
+++ b/src/tools/file_ops.cpp
@@ -128,6 +128,23 @@ std::string FileOps::first_gguf_in_dir(const std::string& path) {
     return "";
 }
 
+std::string FileOps::absolute_path(const std::string& path) {
+    if (path.empty()) return "";
+#ifdef _WIN32
+    char resolved[MAX_PATH];
+    if (_fullpath(resolved, path.c_str(), MAX_PATH) != nullptr) {
+        return std::string(resolved);
+    }
+    return path;
+#else
+    char resolved[PATH_MAX];
+    if (realpath(path.c_str(), resolved) != nullptr) {
+        return std::string(resolved);
+    }
+    return path;
+#endif
+}
+
 std::string FileOps::get_home_dir() {
 #ifdef _WIN32
     char path[MAX_PATH];


### PR DESCRIPTION
…uto to require a model path with -m, utilizing the first .gguf file from models_dir if model_path is empty. Improved error messages for missing models and ensured absolute paths are used for compatibility. Refactored command building to always include -m with validated model paths.