### PR TITLE
Update GLM model entries in models catalog and registry

### DIFF
--- a/assets/src/lib/data/models_catalog.ts
+++ b/assets/src/lib/data/models_catalog.ts
@@ -236,8 +236,8 @@ export const modelsCatalog: ModelFamily[] = [
 		]
 	},
 	{
-		id: 'glm-4.7',
-		name: 'GLM 4.7',
+		id: 'glm',
+		name: 'GLM',
 		description:
 			"Zhipu AI's agentic reasoning and coding models. Built for software engineering, browser automation, and multi-turn tool use.",
 		icon: 'Z',
@@ -245,10 +245,28 @@ export const modelsCatalog: ModelFamily[] = [
 			{
 				name: 'glm-4.7:flash',
 				display_name: 'GLM 4.7 Flash',
-				download_url: 'THUDM/glm-4-7-flash-GGUF',
-				file_size_gb: 2.0,
+				download_url: 'unsloth/GLM-4.7-Flash-GGUF',
+				file_size_gb: 18.3,
 				context_size: 131072,
-				required_ram_gb: calculateRequiredRAM(2.0),
+				required_ram_gb: calculateRequiredRAM(18.3),
+				quantization: 'Q4_K_M'
+			},
+			{
+				name: 'GML-4.6V-Flash',
+				display_name: 'GLM 4.6V Flash',
+				download_url: 'ggml-org/GLM-4.6V-Flash-GGUF',
+				file_size_gb: 6.17,
+				context_size: 131072,
+				required_ram_gb: calculateRequiredRAM(6.17),
+				quantization: 'Q4_K_M'
+			},
+			{
+				name: 'AutoGLM-Phone:9B',
+				display_name: 'GLM 4.1V 9B Base',
+				download_url: 'ggml-org/AutoGLM-Phone-9B-GGUF',
+				file_size_gb: 6.17,
+				context_size: 65536,
+				required_ram_gb: calculateRequiredRAM(6.17),
 				quantization: 'Q4_K_M'
 			}
 		]

--- a/src/models.cpp
+++ b/src/models.cpp
@@ -444,17 +444,7 @@ void ModelManager::init_model_registry() {
         "Gemma 3 27B",
         32768
     };
-    model_registry_["glm-4.7:flash"] = {
-        "glm-4.7:flash",
-        "glm-4.7-flash",
-        "unsloth/GLM-4.7-Flash-GGUF",
-        "GLM-4.7-Flash-Q4_K_M.gguf",
-        "Q4_K_M",
-        2100LL * 1024 * 1024,
-        "GLM 4.7 Flash",
-        "GLM 4.7 Flash",
-        131072
-    };
+   
     model_registry_["devstral-2:24b"] = {
         "devstral-2:24b",
         "devstral-2-24b",
@@ -1560,7 +1550,19 @@ void ModelManager::init_model_registry() {
         "Q4_K_M",
         6170LL * 1024 * 1024,
         "lightweight model optimized for local deployment and low-latency applications",
-        "GML-4.6V-Flash",
+        "GML 4.6V Flash",
+        131072
+    };
+
+    model_registry_["glm-4.7:flash"] = {
+        "glm-4.7-Flash",
+        "glm-4.7-Flash",
+        "unsloth/GLM-4.7-Flash-GGUF",
+        "GLM-4.7-Flash-Q4_K_M.gguf",
+        "Q4_K_M",
+        18300LL * 1024 * 1024,
+        "GLM 4.7 Flash",
+        "GLM 4.7 Flash",
         131072
     };
 
@@ -1572,7 +1574,7 @@ void ModelManager::init_model_registry() {
         "Q4_K_M",
         6170LL * 1024 * 1024,
         "lightweight model optimized for local deployment and low-latency applications",
-        "AutoGLM-Phone-9B",
+        "GLM 4.1V 9B Base",
         65536
     };
 


### PR DESCRIPTION
Refactored the GLM model entries to standardize naming and update download URLs. Added new models for GLM 4.6V Flash and AutoGLM-Phone 9B, while adjusting file sizes and required RAM calculations for consistency. This ensures alignment with the latest model specifications and repository structure.