### PR TITLE
Fix: Version name on final image 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -298,7 +298,24 @@ jobs:
         with:
           tagName: ${{ github.ref_name }}
           releaseName: 'Delta ${{ github.ref_name }}'
-          releaseBody: 'Download the installer for your platform from the assets below.'
+          releaseBody: |
+            Download the installer for your platform from the assets below.
+
+            ### Which file to download
+
+            | File | OS | Notes |
+            |------|----|-------|
+            | `.dmg` | macOS | Disk image installer |
+            | `.deb` | Linux (Ubuntu/Debian) | Install with `sudo dpkg -i` |
+            | `.AppImage` | Linux (any distro) | Portable, no install needed |
+            | `.msi` or `.exe` | Windows | Standard installer |
+
+            ---
+
+            ### Linux AppImage Setup
+
+            1. Make the file executable: `chmod +x Delta_*.AppImage`
+            2. Run it: `./Delta_*.AppImage`
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}
@@ -314,7 +331,33 @@ jobs:
           releaseBody: |
             Download the installer for your platform from the assets below.
 
-            **Note:** macOS builds are not code-signed. Right-click > Open to bypass Gatekeeper.
+            ### Which file to download
+
+            | File | OS | Notes |
+            |------|----|-------|
+            | `.dmg` | macOS | Disk image installer |
+            | `.deb` | Linux (Ubuntu/Debian) | Install with `sudo dpkg -i` |
+            | `.AppImage` | Linux (any distro) | Portable, no install needed |
+            | `.msi` or `.exe` | Windows | Standard installer |
+
+            ---
+
+            ### macOS Setup (unsigned build)
+
+            1. Open the `.dmg` file and drag **Delta** into the **Applications** folder.
+            2. Open Delta from Applications. macOS will show a warning and block it. Click **Done**.
+            3. Go to **System Settings > Privacy & Security**, scroll down, and click **Open Anyway** next to the Delta blocked message.
+            4. Enter your password. Delta will now launch normally.
+
+            > Or run this in Terminal to skip the above:
+            > ```
+            > xattr -cr /Applications/Delta.app
+            > ```
+
+            ### Linux AppImage Setup
+
+            1. Make the file executable: `chmod +x Delta_*.AppImage`
+            2. Run it: `./Delta_*.AppImage`
           releaseDraft: false
           prerelease: false
           args: ${{ matrix.args }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,6 +194,8 @@ jobs:
   # Desktop app release — Tauri bundles (dmg, deb, AppImage, exe)
   # ---------------------------------------------------------------------------
   build-tauri:
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -224,6 +226,12 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           version: 9
+
+      - name: Sync version from version.txt
+        shell: bash
+        run: |
+          chmod +x scripts/bump-version.sh
+          ./scripts/bump-version.sh
 
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
-          vcpkg install curl:x64-windows
+          vcpkg install curl:x64-windows-static-md
 
       - name: Build web UI
         shell: bash
@@ -96,6 +96,7 @@ jobs:
                 -DGGML_METAL=OFF
                 -DUSE_CURL=ON
                 "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+                -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
               )
               ;;
           esac
@@ -253,7 +254,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
-          vcpkg install curl:x64-windows
+          vcpkg install curl:x64-windows-static-md
 
       - name: Build web UI
         shell: bash

--- a/scripts/build-sidecars.sh
+++ b/scripts/build-sidecars.sh
@@ -144,7 +144,7 @@ if [[ -n "$LLAMA_SERVER" ]]; then
     echo "  llama-server -> llama-server-${TARGET_TRIPLE}${EXE_SUFFIX}"
 else
     echo "  WARNING: llama-server not found, searching..."
-    FOUND=$(find "$BUILDDIR" -name "llama-server${EXE_SUFFIX}" -o -name "server${EXE_SUFFIX}" 2>/dev/null | head -1)
+    FOUND=$(find "$BUILDDIR" -type f \( -name "llama-server${EXE_SUFFIX}" -o -name "server${EXE_SUFFIX}" \) 2>/dev/null | head -1)
     if [[ -n "$FOUND" ]]; then
         cp "$FOUND" "$BINDIR/llama-server-${TARGET_TRIPLE}${EXE_SUFFIX}"
         echo "  llama-server -> llama-server-${TARGET_TRIPLE}${EXE_SUFFIX} (from $FOUND)"

--- a/scripts/build-sidecars.sh
+++ b/scripts/build-sidecars.sh
@@ -76,7 +76,10 @@ case "$(uname -s)" in
     MINGW*|MSYS*|CYGWIN*)
         CMAKE_ARGS+=(-DGGML_METAL=OFF -DUSE_CURL=ON)
         if [[ -n "${VCPKG_INSTALLATION_ROOT:-}" ]]; then
-            CMAKE_ARGS+=("-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake")
+            CMAKE_ARGS+=(
+                "-DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake"
+                -DVCPKG_TARGET_TRIPLET=x64-windows-static-md
+            )
         fi
         ;;
 esac


### PR DESCRIPTION
# Description

- VErsiion number on tauri build did not change on each build to use the updated version from version.txt. Now it should be able to pick it up
- Added _how to_ on using unisigned apple image